### PR TITLE
Revert "Move default scales to view instead of static fields"

### DIFF
--- a/HiVRClient.Test/Model/BenchTest.cs
+++ b/HiVRClient.Test/Model/BenchTest.cs
@@ -16,6 +16,33 @@ namespace HiVRClient.Test.Model
         #region Methods
 
         /// <summary>
+        /// Test <see cref="Bench.DefaultPosition"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultPosition()
+        {
+            Assert.That(Bench.DefaultPosition, Is.EqualTo(new Vector3D(0D, 0.2D, 0D)));
+        }
+
+        /// <summary>
+        /// Test <see cref="Bench.DefaultRotation"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultRotation()
+        {
+            Assert.That(Bench.DefaultRotation, Is.EqualTo(new Vector3D(0D, 0D, 0D)));
+        }
+
+        /// <summary>
+        /// Test <see cref="Bench.DefaultScale"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultScale()
+        {
+            Assert.That(Bench.DefaultScale, Is.EqualTo(new Vector3D(0.45D, 0.4D, 1.8D)));
+        }
+
+        /// <summary>
         /// Test constructor.
         /// </summary>
         [Test]

--- a/HiVRClient.Test/Model/BuildingTest.cs
+++ b/HiVRClient.Test/Model/BuildingTest.cs
@@ -16,6 +16,33 @@ namespace HiVRClient.Test.Model
         #region Methods
 
         /// <summary>
+        /// Test <see cref="Building.DefaultPosition"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultPosition()
+        {
+            Assert.That(Building.DefaultPosition, Is.EqualTo(new Vector3D(0D, 3D, 0D)));
+        }
+
+        /// <summary>
+        /// Test <see cref="Building.DefaultRotation"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultRotation()
+        {
+            Assert.That(Building.DefaultRotation, Is.EqualTo(new Vector3D(0D, 0D, 0D)));
+        }
+
+        /// <summary>
+        /// Test <see cref="Building.DefaultScale"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultScale()
+        {
+            Assert.That(Building.DefaultScale, Is.EqualTo(new Vector3D(6D, 6D, 12D)));
+        }
+
+        /// <summary>
         /// Test constructor.
         /// </summary>
         [Test]

--- a/HiVRClient.Test/Model/CarTest.cs
+++ b/HiVRClient.Test/Model/CarTest.cs
@@ -16,6 +16,33 @@ namespace HiVRClient.Test.Model
         #region Methods
 
         /// <summary>
+        /// Test <see cref="Car.DefaultPosition"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultPosition()
+        {
+            Assert.That(Car.DefaultPosition, Is.EqualTo(new Vector3D(0D, 0.75D, 0D)));
+        }
+
+        /// <summary>
+        /// Test <see cref="Car.DefaultRotation"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultRotation()
+        {
+            Assert.That(Car.DefaultRotation, Is.EqualTo(new Vector3D(0D, 0D, 0D)));
+        }
+
+        /// <summary>
+        /// Test <see cref="Car.DefaultScale"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultScale()
+        {
+            Assert.That(Car.DefaultScale, Is.EqualTo(new Vector3D(2.5D, 1.5D, 4.5D)));
+        }
+
+        /// <summary>
         /// Test constructor.
         /// </summary>
         [Test]

--- a/HiVRClient.Test/Model/GardenTest.cs
+++ b/HiVRClient.Test/Model/GardenTest.cs
@@ -16,6 +16,33 @@ namespace HiVRClient.Test.Model
         #region Methods
 
         /// <summary>
+        /// Test <see cref="Garden.DefaultPosition"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultPosition()
+        {
+            Assert.That(Garden.DefaultPosition, Is.EqualTo(new Vector3D(0D, 0.2D, 0D)));
+        }
+
+        /// <summary>
+        /// Test <see cref="Garden.DefaultRotation"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultRotation()
+        {
+            Assert.That(Garden.DefaultRotation, Is.EqualTo(new Vector3D(0D, 0D, 0D)));
+        }
+
+        /// <summary>
+        /// Test <see cref="Garden.DefaultScale"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultScale()
+        {
+            Assert.That(Garden.DefaultScale, Is.EqualTo(new Vector3D(2.5D, 0.4D, 2.5D)));
+        }
+
+        /// <summary>
         /// Test constructor.
         /// </summary>
         [Test]

--- a/HiVRClient.Test/Model/TelevisionTest.cs
+++ b/HiVRClient.Test/Model/TelevisionTest.cs
@@ -16,6 +16,33 @@ namespace HiVRClient.Test.Model
         #region Methods
 
         /// <summary>
+        /// Test <see cref="Television.DefaultPosition"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultPosition()
+        {
+            Assert.That(Television.DefaultPosition, Is.EqualTo(new Vector3D(0D, 0D, 0D)));
+        }
+
+        /// <summary>
+        /// Test <see cref="Television.DefaultRotation"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultRotation()
+        {
+            Assert.That(Television.DefaultRotation, Is.EqualTo(new Vector3D(0D, 180D, 0D)));
+        }
+
+        /// <summary>
+        /// Test <see cref="Television.DefaultScale"/> field.
+        /// </summary>
+        [Test]
+        public void TestDefaultScale()
+        {
+            Assert.That(Television.DefaultScale, Is.EqualTo(new Vector3D(1.6D, 0.9D, 1D)));
+        }
+
+        /// <summary>
         /// Test constructor.
         /// </summary>
         [Test]

--- a/HiVRClient/Model/Bench.cs
+++ b/HiVRClient/Model/Bench.cs
@@ -10,6 +10,25 @@ namespace HiVRClient.Model
     /// </summary>
     public class Bench : Drawable
     {
+        #region Properties
+
+        /// <summary>
+        /// Gets the position of this Bench.
+        /// </summary>
+        public static readonly Vector3D DefaultPosition = new Vector3D(0D, 0.2D, 0D);
+
+        /// <summary>
+        /// Gets the rotation of this Bench.
+        /// </summary>
+        public static readonly Vector3D DefaultRotation = new Vector3D(0D, 0D, 0D);
+
+        /// <summary>
+        /// Gets the scale of this Bench.
+        /// </summary>
+        public static readonly Vector3D DefaultScale = new Vector3D(0.45D, 0.4D, 1.8D);
+
+        #endregion Properties
+
         #region Constructors
 
         /// <summary>

--- a/HiVRClient/Model/Building.cs
+++ b/HiVRClient/Model/Building.cs
@@ -10,6 +10,25 @@ namespace HiVRClient.Model
     /// </summary>
     public class Building : Drawable
     {
+        #region Fields
+
+        /// <summary>
+        /// Gets the position of this Building.
+        /// </summary>
+        public static readonly Vector3D DefaultPosition = new Vector3D(0D, 3D, 0D);
+
+        /// <summary>
+        /// Gets the rotation of this Building.
+        /// </summary>
+        public static readonly Vector3D DefaultRotation = new Vector3D(0D, 0D, 0D);
+
+        /// <summary>
+        /// Gets the scale of this Building.
+        /// </summary>
+        public static readonly Vector3D DefaultScale = new Vector3D(6D, 6D, 12D);
+
+        #endregion Fields
+
         #region Constructors
 
         /// <summary>

--- a/HiVRClient/Model/Car.cs
+++ b/HiVRClient/Model/Car.cs
@@ -10,6 +10,25 @@ namespace HiVRClient.Model
     /// </summary>
     public class Car : Drawable
     {
+        #region Properties
+
+        /// <summary>
+        /// Gets the position of this Car.
+        /// </summary>
+        public static readonly Vector3D DefaultPosition = new Vector3D(0D, 0.75D, 0D);
+
+        /// <summary>
+        /// Gets the rotation of this Car.
+        /// </summary>
+        public static readonly Vector3D DefaultRotation = new Vector3D(0D, 0D, 0D);
+
+        /// <summary>
+        /// Gets the scale of this Car.
+        /// </summary>
+        public static readonly Vector3D DefaultScale = new Vector3D(2.5D, 1.5D, 4.5D);
+
+        #endregion Properties
+
         #region Constructors
 
         /// <summary>

--- a/HiVRClient/Model/Garden.cs
+++ b/HiVRClient/Model/Garden.cs
@@ -10,6 +10,25 @@ namespace HiVRClient.Model
     /// </summary>
     public class Garden : Drawable
     {
+        #region Properties
+
+        /// <summary>
+        /// Gets the position of this Garden.
+        /// </summary>
+        public static readonly Vector3D DefaultPosition = new Vector3D(0D, 0.2D, 0D);
+
+        /// <summary>
+        /// Gets the rotation of this Garden.
+        /// </summary>
+        public static readonly Vector3D DefaultRotation = new Vector3D(0D, 0D, 0D);
+
+        /// <summary>
+        /// Gets the scale of this Garden.
+        /// </summary>
+        public static readonly Vector3D DefaultScale = new Vector3D(2.5D, 0.4D, 2.5D);
+
+        #endregion Properties
+
         #region Constructors
 
         /// <summary>

--- a/HiVRClient/Model/Television.cs
+++ b/HiVRClient/Model/Television.cs
@@ -10,6 +10,25 @@ namespace HiVRClient.Model
     /// </summary>
     public class Television : Drawable
     {
+        #region Properties
+
+        /// <summary>
+        /// Gets the position of this Television.
+        /// </summary>
+        public static readonly Vector3D DefaultPosition = new Vector3D(0D, 0D, 0D);
+
+        /// <summary>
+        /// Gets the rotation of this Television.
+        /// </summary>
+        public static readonly Vector3D DefaultRotation = new Vector3D(0D, 180D, 0D);
+
+        /// <summary>
+        /// Gets the scale of this Television.
+        /// </summary>
+        public static readonly Vector3D DefaultScale = new Vector3D(1.6D, 0.9D, 1D);
+
+        #endregion Properties
+
         #region Constructors
 
         /// <summary>

--- a/HiVRClient/View/DrawableTemplate.xaml
+++ b/HiVRClient/View/DrawableTemplate.xaml
@@ -7,7 +7,7 @@
             RenderTransformOrigin="0.5, 0.5">
             <Path.Data>
                 <RectangleGeometry
-                    Rect="0, 0, 6, 12" />
+                    Rect="0,0,1,1" />
             </Path.Data>
             <Path.Style>
                 <Style
@@ -27,6 +27,7 @@
                     <TranslateTransform
                         X="{Binding Position.X}"
                         Y="{Binding Position.Z}" />
+
                 </TransformGroup>
             </Path.RenderTransform>
         </Path>
@@ -37,7 +38,7 @@
             RenderTransformOrigin="0.5, 0.5">
             <Path.Data>
                 <RectangleGeometry
-                    Rect="0, 0, 2.5, 4.5"
+                    Rect="0,0,1,1"
                     RadiusX="0.3"
                     RadiusY="0.3" />
             </Path.Data>
@@ -69,7 +70,7 @@
             RenderTransformOrigin="0.5, 0.5">
             <Path.Data>
                 <RectangleGeometry
-                    Rect="0, 0, 2.5, 2.5" />
+                    Rect="0,0,1,1" />
             </Path.Data>
             <Path.Style>
                 <Style
@@ -99,7 +100,7 @@
             RenderTransformOrigin="0.5, 0.5">
             <Path.Data>
                 <RectangleGeometry
-                    Rect="0, 0, 0.45, 1.8" />
+                    Rect="0,0,1,1" />
             </Path.Data>
             <Path.Style>
                 <Style
@@ -129,7 +130,7 @@
             RenderTransformOrigin="0.5, 0.5">
             <Path.Data>
                 <RectangleGeometry
-                    Rect="0, 0, 1.6, 1" />
+                    Rect="0,0,1,1" />
             </Path.Data>
             <Path.Style>
                 <Style


### PR DESCRIPTION
Reverts HiVR/HiVRClient#31

It messes up the translation of the drawables. When they are only 1x1 px it doesn't matter if they scale from the left upper corner or the center, but when they are a little bigger than that, it isn't correct anymore
